### PR TITLE
feat: Pass Environment Variable from 'env' option

### DIFF
--- a/rust-pty/src/lib.rs
+++ b/rust-pty/src/lib.rs
@@ -33,6 +33,33 @@ fn debug(msg: &str) {
     }
 }
 
+fn parse_env_string(env_ptr: *const c_char) -> HashMap<String, String> {
+    if env_ptr.is_null() {
+        return HashMap::new();
+    }
+
+    let mut env_map = HashMap::new();
+    let mut current_ptr = env_ptr;
+
+    unsafe {
+        while *current_ptr != 0 {
+            let cstr = CStr::from_ptr(current_ptr);
+            
+            if let Ok(env_str) = cstr.to_str() {
+                if let Some((key, value)) = env_str.split_once('=') {
+                    if !key.is_empty() {
+                        env_map.insert(key.to_string(), value.to_string());
+                    }
+                }
+            }
+
+            current_ptr = current_ptr.add(cstr.to_bytes_with_nul().len());
+        }
+    }
+
+    env_map
+}
+
 /* ---------- command struct ---------- */
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,7 +71,7 @@ struct Command {
 }
 
 impl Command {
-    fn from_cmdline(cmdline: &str, cwd: &str) -> Self {
+    fn from_cmdline(cmdline: &str, cwd: &str, env_ptr: *const c_char) -> Self {
         let tokens = split(cmdline).unwrap_or_default();   // shell-accurate split
         if tokens.is_empty() {
             return Self {
@@ -58,7 +85,7 @@ impl Command {
         let cmd  = tokens[0].clone();
         let args = tokens[1..].to_vec();
 
-        let env = std::env::vars().collect();              // forward everything
+        let env = parse_env_string(env_ptr);
 
         Self { cmd, args, env, cwd: cwd.to_owned() }
     }
@@ -242,6 +269,7 @@ fn with<F: FnOnce(&Arc<Pty>) -> c_int>(id: u32, f: F) -> c_int {
 pub unsafe extern "C" fn bun_pty_spawn(
     cmd:  *const c_char,
     cwd:  *const c_char,
+    env:  *const c_char,
     cols: c_int,
     rows: c_int,
 ) -> c_int {
@@ -251,7 +279,8 @@ pub unsafe extern "C" fn bun_pty_spawn(
     let cwd     = unsafe { CStr::from_ptr(cwd) }.to_string_lossy();
 
     let size = PtySize { cols: cols as u16, rows: rows as u16, pixel_width: 0, pixel_height: 0 };
-    match Pty::new(Command::from_cmdline(&cmdline, &cwd), size) {
+    let cmd = Command::from_cmdline(&cmdline, &cwd, env);
+    match Pty::new(cmd, size) {
         Ok(p)  => store(Arc::new(p)) as c_int,
         Err(e) => { debug(&format!("spawn error: {e}")); ERROR },
     }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -35,7 +35,7 @@ function resolveLibPath(): string {
 	// Start from the current module's location (inside node_modules/bun-pty/dist)
 	const base = Bun.fileURLToPath(import.meta.url);
 	const here = base.replace(/\/dist\/.*$/, ""); // up to bun-pty/
-
+	
 	const fallbackPaths = [
 		join(here, "rust-pty", "target", "release", filename),       // node_modules/bun-pty/rust-pty/target/release
 		join(here, "..", "bun-pty", "rust-pty", "target", "release", filename), // monorepo setups
@@ -60,7 +60,7 @@ let lib: any;
 try {
 	lib = dlopen(libPath, {
 		bun_pty_spawn: {
-			args: [FFIType.cstring, FFIType.cstring, FFIType.i32, FFIType.i32],
+			args: [FFIType.cstring, FFIType.cstring, FFIType.cstring, FFIType.i32, FFIType.i32],
 			returns: FFIType.i32,
 		},
 		bun_pty_write: {
@@ -104,12 +104,19 @@ export class Terminal implements IPty {
 		this._cols = opts.cols ?? DEFAULT_COLS;
 		this._rows = opts.rows ?? DEFAULT_ROWS;
 		const cwd = opts.cwd ?? process.cwd();
-
 		const cmdline = [file, ...args].join(" ");
+
+		// Format environment variables as null-terminated string
+		let envStr = "";
+		if (opts.env) {
+			const envPairs = Object.entries(opts.env).map(([k, v]) => `${k}=${v}`);
+			envStr = envPairs.join("\0") + "\0";
+		}
 
 		this.handle = lib.symbols.bun_pty_spawn(
 			Buffer.from(`${cmdline}\0`, "utf8"),
 			Buffer.from(`${cwd}\0`, "utf8"),
+			Buffer.from(`${envStr}\0`, "utf8"),
 			this._cols,
 			this._rows,
 		);

--- a/test-pty.js
+++ b/test-pty.js
@@ -15,7 +15,7 @@ console.log(`Opening shared library: ${libraryPath}`);
 // Define the FFI interface
 const lib = dlopen(libraryPath, {
   bun_pty_spawn: {
-    args: [FFIType.cstring, FFIType.cstring, FFIType.i32, FFIType.i32],
+    args: [FFIType.cstring, FFIType.cstring, FFIType.cstring, FFIType.i32, FFIType.i32],
     returns: FFIType.i32
   },
   bun_pty_read: {
@@ -52,8 +52,9 @@ async function runTest() {
   // Create null-terminated C strings
   const cmd = Buffer.from("bash\0", "utf8");
   const cwd = Buffer.from(`${process.cwd()}\0`, "utf8");
-  
-  const ptyHandle = symbols.bun_pty_spawn(cmd, cwd, 80, 24);
+  const env = Buffer.from("TEST_VAR=test_value\0\0", "utf8");
+
+  const ptyHandle = symbols.bun_pty_spawn(cmd, cwd, env, 80, 24);
   
   if (ptyHandle < 0) {
     console.error("Failed to create PTY!");


### PR DESCRIPTION
Problem: The `IPtyForkOptions.env` property was defined but not used, all env variables were passed from the[ parent process](https://github.com/sursaone/bun-pty/blob/d46d4ab1f43a96f4695934e152767b95933e5e8a/rust-pty/src/lib.rs#L61).

This PR ensures that environment variables are passed through `IPtyForkOptions.env`. If the user wants to inherit the environment variables from the parent process, they can do so by including `...process.env`, like this:

```js
const pty = new Terminal('bash', [], {
  env: { 
      ...process.env, 
      TEST_VAR: 'value' 
     }
});
```

Disclaimer: I am not very familiar with Rust and have relied on AI assistance.