### PR TITLE
fix: improve regex for path resolution to handle both Unix and Windows separators

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -34,7 +34,7 @@ function resolveLibPath(): string {
 
 	// Start from the current module's location (inside node_modules/bun-pty/dist)
 	const base = Bun.fileURLToPath(import.meta.url);
-	const here = base.replace(/\/dist\/.*$/, ""); // up to bun-pty/
+	const here = base.replace(/[\/\\]dist[\/\\].*$/, ""); // up to bun-pty/
 
 	const fallbackPaths = [
 		join(here, "rust-pty", "target", "release", filename),       // node_modules/bun-pty/rust-pty/target/release


### PR DESCRIPTION
This PR cherry-picks the path resolution fix to improve regex handling for both Unix and Windows path separators.

Cherry-picked from commit 208c302d90b2f6fbd72c850eea24345630458b97