### PR TITLE
fix: increase read buffer to 8192 bytes to match Rust backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bun-pty",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Cross-platform pseudoterminal (PTY) implementation for Bun with native performance",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -170,7 +170,7 @@ export class Terminal implements IPty {
 		if (this._readLoop) return;
 		this._readLoop = true;
 
-		const buf = Buffer.allocUnsafe(4096);
+		const buf = Buffer.allocUnsafe(8192);
 
 		while (this._readLoop && !this._closing) {
 			const n = lib.symbols.bun_pty_read(this.handle, ptr(buf), buf.length);


### PR DESCRIPTION
## Summary

Fix data loss caused by buffer size mismatch between the TypeScript frontend and Rust backend.

## Problem

The Rust backend allocates an 8192-byte buffer for reading PTY output (`lib.rs:147`), but the TypeScript frontend was only allocating a 4096-byte buffer (`terminal.ts:173`). 

When the PTY produced more than 4KB of output in a single read cycle, `bun_pty_read` would truncate the data to fit the smaller JS buffer, causing silent data loss.

## Solution

Increased the TypeScript read buffer from 4096 to 8192 bytes to match the Rust backend.

## Changes

- `src/terminal.ts`: Changed `Buffer.allocUnsafe(4096)` to `Buffer.allocUnsafe(8192)`
