### PR TITLE
fix: use ubuntu-22.04 for GLIBC 2.35 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Use ubuntu-20.04 for GLIBC 2.31 compatibility (ubuntu-latest has GLIBC 2.39)
-          - runner: ubuntu-20.04
+          # Use ubuntu-22.04 for GLIBC 2.35 compatibility (ubuntu-latest has GLIBC 2.39)
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             out:    librust_pty.so
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             out:    librust_pty_arm64.so
           - runner: macos-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-latest
+          # Use ubuntu-20.04 for GLIBC 2.31 compatibility (ubuntu-latest has GLIBC 2.39)
+          - runner: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             out:    librust_pty.so
-          - runner: ubuntu-latest
+          - runner: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             out:    librust_pty_arm64.so
           - runner: macos-latest


### PR DESCRIPTION
The current workflow uses `ubuntu-latest` which is Ubuntu 24.04 with GLIBC 2.39.

This causes the built `.so` files to require GLIBC 2.39, breaking compatibility with older Linux distros.

This PR switches Linux builds to `ubuntu-22.04` (GLIBC 2.35) for broader compatibility.

cc @sursaone

Related issues:
- sst/opencode#5685
- remorses/tuistory#1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI runner images from the latest distro to Ubuntu 22.04 for selected Linux builds to ensure consistent GLIBC compatibility and more reliable artifacts. A comment was added clarifying the compatibility rationale.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->