### PR TITLE
fix: restore .d.ts type declarations for TypeScript compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,5 +118,8 @@ jobs:
       - name: List bundled libs
         run: ls -R ${{ env.RELEASE_DIR }}
 
+      - name: Build TypeScript declarations
+        run: bun run build:ts
+
       - name: Publish to npm
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.4.5",
 	"description": "Cross-platform pseudoterminal (PTY) implementation for Bun with native performance",
 	"main": "./src/index.ts",
-	"types": "./src/index.ts",
+	"types": "./dist/index.d.ts",
 	"type": "module",
 	"repository": {
 		"type": "git",
@@ -44,7 +44,8 @@
 		"prepare": "bun run build",
 		"prepack": "bun run build",
 		"build:rust": "cd rust-pty && cargo build --release",
-		"build": "bun run build:rust",
+		"build:ts": "tsc --emitDeclarationOnly --declaration --outDir dist",
+		"build": "bun run build:rust && bun run build:ts",
 		"test": "bun test",
 		"test:unit": "bun test src/interfaces.test.ts src/terminal.test.ts src/index.test.ts",
 		"test:integration": "RUN_INTEGRATION_TESTS=true bun test src/terminal.integration.test.ts",
@@ -56,9 +57,8 @@
 		"bun": ">=1.0.0"
 	},
 	"files": [
-		"src/index.ts",
-		"src/terminal.ts",
-		"src/interfaces.ts",
+		"src",
+		"dist",
 		"README.md",
 		"LICENSE",
 		"CHANGELOG.md",


### PR DESCRIPTION
PR #25 changed the package to ship TypeScript source files directly for bun compile support, but it also changed the `types` field from `./dist/index.d.ts` to `./src/index.ts`. This causes TypeScript errors in consumer projects that use stricter tsconfig settings like `moduleResolution: "NodeNext"` or `module: "NodeNext"`, which require `.js` extensions in imports and don't work well with raw `.ts` source files as type definitions.

This PR restores proper `.d.ts` declaration file generation while keeping the bun compile fix intact:
- `types` now points to `./dist/index.d.ts` again
- Added `build:ts` script to generate declaration files
- Updated CI to build declarations before publishing
- Kept `main` pointing to `./src/index.ts` for bun compile support

This PR was written by Opus 4.5 under the strict supervision of @remorses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to automatically generate TypeScript type declarations during the build process. Type declarations are now compiled and distributed with each release, improving IDE support and type safety for TypeScript users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->