### PR TITLE
build: switch Linux builds to musl with static libc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Use ubuntu-22.04 for GLIBC 2.35 compatibility (ubuntu-latest has GLIBC 2.39)
+          # musl static builds for all Linux (no glibc dependency)
           - runner: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             out:    librust_pty.so
           - runner: ubuntu-22.04
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             out:    librust_pty_arm64.so
           - runner: macos-latest
             target: x86_64-apple-darwin
@@ -45,22 +45,24 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install aarch64 linker
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'musl')
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+          sudo apt-get install -y musl-tools
+          pip3 install ziglang
+          cargo install cargo-zigbuild
 
-      - name: Configure aarch64 linker
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Build rust-pty (musl via zigbuild with static libc)
+        if: contains(matrix.target, 'musl')
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
         run: |
-          mkdir -p rust-pty/.cargo
-          cat > rust-pty/.cargo/config.toml << 'EOF'
-          [target.aarch64-unknown-linux-gnu]
-          linker = "aarch64-linux-gnu-gcc"
-          EOF
+          cd rust-pty
+          cargo zigbuild --release --target ${{ matrix.target }}
 
       - name: Build rust-pty
+        if: "!contains(matrix.target, 'linux')"
         run: |
           cd rust-pty
           cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - runner: macos-latest
             target: x86_64-apple-darwin
           - runner: macos-latest
@@ -39,7 +39,24 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          pip3 install ziglang
+          cargo install cargo-zigbuild
+
+      - name: Build Rust library (musl with static libc)
+        if: contains(matrix.target, 'musl')
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
+        run: |
+          cd rust-pty
+          cargo zigbuild --release --target ${{ matrix.target }}
+
       - name: Build Rust library
+        if: "!contains(matrix.target, 'musl')"
         run: |
           cd rust-pty
           cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Replace glibc targets with musl targets for Linux builds. This eliminates runtime dependency on system libc and ensures the shared library works across all Linux distributions.

Changes:
- Use x86_64-unknown-linux-musl and aarch64-unknown-linux-musl targets
- Build with cargo-zigbuild for cross-compilation
- Enable static libc linking via RUSTFLAGS="-C target-feature=+crt-static"
- Remove glibc-specific linker configuration (no longer needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to generate musl-based binaries for x86_64 and aarch64 Linux architectures, replacing previous glibc-based builds
  * Enhanced binary portability and compatibility across different Linux distributions and systems through improved static linking approaches
  * Optimized CI/CD workflows to support both musl and non-musl build paths for broader system compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->