### PR TITLE
chore: release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-01-10
+
+### Changed
+- Use glibc 2.17 via cargo-zigbuild for Linux builds (#30)
+  - Updated build process to use cargo-zigbuild targeting glibc 2.17
+  - Improves compatibility with older Linux distributions
+  - Ensures binaries work on systems with glibc 2.17 and newer
+
 ## [0.4.6] - 2026-01-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bun-pty",
-	"version": "0.4.6",
+	"version": "0.4.7",
 	"description": "Cross-platform pseudoterminal (PTY) implementation for Bun with native performance",
 	"main": "./src/index.ts",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.7
  * Linux binaries now target glibc 2.17, extending compatibility to older Linux distributions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->