### PR TITLE
fix: add musl libc support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,17 @@ jobs:
             target: aarch64-unknown-linux-gnu
             zigbuild_target: aarch64-unknown-linux-gnu.2.17
             out:    librust_pty_arm64.so
+          # musl builds (Alpine Linux and other musl-based distros)
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            zigbuild_target: x86_64-unknown-linux-musl
+            out:    librust_pty_musl.so
+            rustflags: -C target-feature=-crt-static
+          - runner: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+            zigbuild_target: aarch64-unknown-linux-musl
+            out:    librust_pty_arm64_musl.so
+            rustflags: -C target-feature=-crt-static
           - runner: macos-latest
             target: x86_64-apple-darwin
             out:    librust_pty.dylib
@@ -55,6 +66,8 @@ jobs:
 
       - name: Build rust-pty (Linux with zigbuild)
         if: matrix.zigbuild_target
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
           cd rust-pty
           cargo zigbuild --release --target ${{ matrix.zigbuild_target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-gnu
 
+
     steps:
       - uses: actions/checkout@v4
 
@@ -80,3 +81,66 @@ jobs:
           path: coverage/lcov.info
           if-no-files-found: ignore
 
+  build-musl-lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install zigbuild
+        run: |
+          pip3 install ziglang
+          cargo install cargo-zigbuild
+
+      - name: Build Rust library (musl with zigbuild)
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
+        run: cd rust-pty && cargo zigbuild --release --target x86_64-unknown-linux-musl
+
+      - name: Upload musl library
+        uses: actions/upload-artifact@v4
+        with:
+          name: librust_pty_musl
+          path: rust-pty/target/x86_64-unknown-linux-musl/release/librust_pty.so
+
+  test-musl:
+    needs: build-musl-lib
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.23
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: apk add --no-cache bash curl libgcc libstdc++
+
+      - name: Download musl library
+        uses: actions/download-artifact@v4
+        with:
+          name: librust_pty_musl
+          path: rust-pty/target/release/
+
+      - name: Rename library to musl variant
+        run: mv rust-pty/target/release/librust_pty.so rust-pty/target/release/librust_pty_musl.so
+
+      - name: Install Bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+
+      - name: Install JS dependencies
+        run: $HOME/.bun/bin/bun install --ignore-scripts
+
+      - name: Run unit tests
+        run: $HOME/.bun/bin/bun run test:unit
+
+      - name: Run integration tests
+        run: $HOME/.bun/bin/bun run test:integration
+        env:
+          RUN_INTEGRATION_TESTS: true

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -5,7 +5,7 @@ import { Buffer } from "node:buffer";
 import { EventEmitter } from "./interfaces";
 import type { IPty, IPtyForkOptions, IExitEvent } from "./interfaces";
 import { join, dirname, basename } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 export const DEFAULT_COLS = 80;
 export const DEFAULT_ROWS = 24;
@@ -28,9 +28,20 @@ function shQuote(s: string): string {
 
 // terminal.ts  – loader fragment only
 
+function isMusl(): boolean {
+	if (process.platform !== "linux") return false;
+	try {
+		return readFileSync("/proc/self/maps", "utf8").includes("ld-musl");
+	} catch {
+		return false;
+	}
+}
+
 function resolveLibPath(): string {
 	const env = process.env.BUN_PTY_LIB;
 	if (env && existsSync(env)) return env;
+
+	const musl = isMusl();
 
 	// For bun compile: use statically analyzable require with inline ternary.
 	// Bun evaluates process.platform and process.arch at compile time and only
@@ -40,9 +51,22 @@ function resolveLibPath(): string {
 	try {
 		// @ts-ignore - require returns path for binary files in Bun
 		const embeddedPath = require(`../rust-pty/target/release/${process.platform === "win32" ? "rust_pty.dll" : process.platform === "darwin" ? (process.arch === "arm64" ? "librust_pty_arm64.dylib" : "librust_pty.dylib") : process.arch === "arm64" ? "librust_pty_arm64.so" : "librust_pty.so"}`);
-		if (embeddedPath) return embeddedPath;
+		if (embeddedPath && !musl) return embeddedPath;
 	} catch {
 		// Not running as compiled binary, fall through to dynamic resolution
+	}
+
+	// For bun compile on Linux musl: embed the musl-specific variant.
+	// The process.platform guard ensures Bun does not bundle Linux .so files
+	// into non-Linux compiled binaries.
+	if (process.platform === "linux") {
+		try {
+			// @ts-ignore - require returns path for binary files in Bun
+			const embeddedMuslPath = require(`../rust-pty/target/release/${process.arch === "arm64" ? "librust_pty_arm64_musl.so" : "librust_pty_musl.so"}`);
+			if (embeddedMuslPath && musl) return embeddedMuslPath;
+		} catch {
+			// Not running as compiled binary, fall through to dynamic resolution
+		}
 	}
 
 	// Fallback: dynamic resolution for development scenarios
@@ -57,6 +81,10 @@ function resolveLibPath(): string {
 				: ["librust_pty.dylib"]
 			: platform === "win32"
 			? ["rust_pty.dll"]
+			: musl
+			? arch === "arm64"
+				? ["librust_pty_arm64_musl.so", "librust_pty_musl.so", "librust_pty_arm64.so", "librust_pty.so"]
+				: ["librust_pty_musl.so", "librust_pty.so"]
 			: arch === "arm64"
 			? ["librust_pty_arm64.so", "librust_pty.so"]
 			: ["librust_pty.so"];


### PR DESCRIPTION
- Ship pre-built musl variants (librust_pty_musl.so / librust_pty_arm64_musl.so) alongside the existing glibc builds via cargo-zigbuild
- Detect musl at runtime via the dynamic linker path and load the appropriate .so
- Add test-musl CI job running inside alpine:3.23

fixes https://github.com/sursaone/bun-pty/issues/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for musl-based Linux distributions with runtime detection and automatic selection of musl-specific library variants.

* **Tests**
  * CI updated to build musl library artifacts and run musl-targeted test jobs (including Alpine-based test runs) to ensure coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->