### PR TITLE
fix: bump portable-pty to 0.9.0 so bare command names aren't shadowed by cwd directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Spawn a bare command name even when a same-named directory exists in the cwd
+  - Bump `portable-pty` to 0.9.0, whose `search_path` now skips non-executable candidates (including directories) instead of blindly accepting `cwd/<command>` just because it exists.
+  - Previously, spawning e.g. `cmake` from a project that contains a `cmake/` directory resolved to that directory, so the child tried to exec a directory and either aborted with `fatal runtime error: assertion failed: output.write(&bytes).is_ok()` or surfaced as `PTY spawn failed`.
+
 ## [0.4.10] - 2026-06-15
 
 ### Added

--- a/rust-pty/Cargo.lock
+++ b/rust-pty/Cargo.lock
@@ -9,22 +9,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "crossbeam"
@@ -100,15 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ioctl-rs"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,42 +136,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "autocfg",
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset",
- "pin-utils",
 ]
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-pty"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "filedescriptor",
  "lazy_static",
@@ -183,7 +163,7 @@ dependencies = [
  "nix",
  "serde",
  "serde_derive",
- "serial",
+ "serial2",
  "shared_library",
  "shell-words",
  "winapi",
@@ -259,45 +239,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial"
-version = "0.4.0"
+name = "serial2"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
 dependencies = [
- "serial-core",
- "serial-unix",
- "serial-windows",
-]
-
-[[package]]
-name = "serial-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
-dependencies = [
+ "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "serial-unix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
-dependencies = [
- "ioctl-rs",
- "libc",
- "serial-core",
- "termios",
-]
-
-[[package]]
-name = "serial-windows"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
-dependencies = [
- "libc",
- "serial-core",
+ "windows-sys",
 ]
 
 [[package]]
@@ -325,15 +274,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termios"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -383,6 +323,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winreg"

--- a/rust-pty/Cargo.toml
+++ b/rust-pty/Cargo.toml
@@ -15,7 +15,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # https://github.com/wezterm/wezterm/issues/6783
-portable-pty = { version = "0.8.1", features = ["serde_support"] }
+# 0.9.0 fixes search_path so a bare command name is no longer shadowed by a
+# same-named directory in the cwd.
+portable-pty = { version = "0.9.0", features = ["serde_support"] }
 lazy_static = "1.4"
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Problem

`bun-pty` ships with `portable-pty 0.8.1`, whose `CommandBuilder::search_path` accepts `cwd/<command>` whenever that path merely **exists**, without checking that it is an executable file:

```rust
let abs_path = cwd.join(exe_path);
if abs_path.exists() {
    return Ok(abs_path.into_os_string());
}
```

So when the working directory contains a directory that shares a name with the command being spawned, the child tries to `exec` a **directory**. On macOS this makes the child abort with

```
fatal runtime error: assertion failed: output.write(&bytes).is_ok(), aborting
```

and, depending on timing of the exec-error status pipe, can also surface as `PTY spawn failed` from `bun_pty_spawn`.

Concrete repro: in a project containing a `cmake/` directory, spawn `cmake --version` with `cwd` set to that project.

## Fix

Bump `portable-pty` from `0.8.1` to `0.9.0`. Its `search_path` now:

- treats only explicitly cwd-relative paths (`./foo`, `../foo`) as cwd-relative,
- skips candidates that are directories or not executable,
- and errors out with a clear message otherwise.

The `cwd/cmake` directory no longer shadows the `cmake` binary on `$PATH`.

## Verification

Rebuilt `rust-pty` with the bumped dependency and confirmed in a project containing a `cmake/` directory:

- `cmake --version` (bare name, previously broken) now runs the real binary and prints `cmake version ...`
- `cargo --version`, `rustc --version`, `git --version` still spawn fine

No API changes required in `rust-pty` — `portable-pty 0.9.0` keeps the same `PtySystem`/`CommandBuilder`/`MasterPty`/`SlavePty` interfaces used here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when launching commands that share a name with a directory in the current location.
  * Improved terminal command spawning reliability.

* **Documentation**
  * Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->