### PR TITLE
feat: add native Windows ARM64 support

### DIFF
--- a/.github/scripts/windows-arm64-compile-smoke.ts
+++ b/.github/scripts/windows-arm64-compile-smoke.ts
@@ -1,0 +1,27 @@
+import { spawn } from "../../src/index";
+
+const marker = "BUN_PTY_COMPILED_ARM64_OK";
+const terminal = spawn("cmd.exe", ["/d", "/c", `echo ${marker}`], {
+	name: "xterm",
+	cols: 80,
+	rows: 24,
+	cwd: process.cwd(),
+	env: process.env,
+});
+
+let output = "";
+
+terminal.onData((data) => {
+	output += data;
+});
+
+terminal.onExit(({ exitCode }) => {
+	if (exitCode === 0 && output.includes(marker)) process.exit(0);
+	console.error(`Compiled PTY smoke test failed with exit code ${exitCode}: ${output}`);
+	process.exit(1);
+});
+
+setTimeout(() => {
+	console.error(`Compiled PTY smoke test timed out: ${output}`);
+	process.exit(1);
+}, 5_000);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
             out:    rust_pty_arm64.dll
+            rustflags: -C target-feature=+crt-static
 
     steps:
       - uses: actions/checkout@v4
@@ -77,6 +78,8 @@ jobs:
 
       - name: Build rust-pty
         if: "!matrix.zigbuild_target"
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
           cd rust-pty
           cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-gnu
             out:    rust_pty.dll
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            out:    rust_pty_arm64.dll
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,13 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
 
+      - name: Test compiled Windows ARM64 binary
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          bun build --compile --target=bun-windows-arm64 .github/scripts/windows-arm64-compile-smoke.ts --outfile "$env:RUNNER_TEMP/bun-pty-windows-arm64-smoke.exe"
+          & "$env:RUNNER_TEMP/bun-pty-windows-arm64-smoke.exe"
+
       - name: Upload coverage to artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
             target: x86_64-pc-windows-gnu
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
+            rustflags: -C target-feature=+crt-static
 
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +57,8 @@ jobs:
 
       - name: Build Rust library
         if: "!matrix.zigbuild_target"
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
           cd rust-pty
           cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-gnu
-
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +62,13 @@ jobs:
 
       - name: Install dependencies
         run: bun install
+
+      - name: Prepare Windows ARM64 library
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          Copy-Item rust-pty/target/${{ matrix.target }}/release/rust_pty.dll rust-pty/target/release/rust_pty_arm64.dll
+          Remove-Item rust-pty/target/release/rust_pty.dll
 
       - name: Run unit tests
         run: bun run test:unit

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bun add bun-pty
 |----------|--------|-------|
 | macOS    | ✅     | Fully supported |
 | Linux    | ✅     | Fully supported |
-| Windows  | ✅     | Fully supported |
+| Windows (x64, ARM64) | ✅ | Fully supported |
 
 ## 🚦 Usage
 

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,20 @@
+export function libraryFilenames(platform: typeof process.platform, arch: string, musl: boolean) {
+	if (platform === "darwin") {
+		return arch === "arm64"
+			? ["librust_pty_arm64.dylib", "librust_pty.dylib"]
+			: ["librust_pty.dylib"];
+	}
+	if (platform === "win32") {
+		return arch === "arm64"
+			? ["rust_pty_arm64.dll", "rust_pty.dll"]
+			: ["rust_pty.dll"];
+	}
+	if (musl) {
+		return arch === "arm64"
+			? ["librust_pty_arm64_musl.so", "librust_pty_musl.so", "librust_pty_arm64.so", "librust_pty.so"]
+			: ["librust_pty_musl.so", "librust_pty.so"];
+	}
+	return arch === "arm64"
+		? ["librust_pty_arm64.so", "librust_pty.so"]
+		: ["librust_pty.so"];
+}

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -1,6 +1,20 @@
 import { expect, test, describe } from "bun:test";
 import { DEFAULT_COLS, DEFAULT_ROWS, DEFAULT_FILE, DEFAULT_NAME } from "./terminal";
 import type { IPtyForkOptions, IExitEvent } from "./interfaces";
+import { libraryFilenames } from "./library";
+
+describe("native library resolution", () => {
+	test("prefers the ARM64 DLL on Windows ARM64", () => {
+		expect(libraryFilenames("win32", "arm64", false)).toEqual([
+			"rust_pty_arm64.dll",
+			"rust_pty.dll",
+		]);
+	});
+
+	test("keeps the generic DLL name on Windows x64", () => {
+		expect(libraryFilenames("win32", "x64", false)).toEqual(["rust_pty.dll"]);
+	});
+});
 
 describe("Terminal configuration and options", () => {
 	describe("default values", () => {
@@ -394,4 +408,3 @@ describe("Terminal constants", () => {
 		expect(DEFAULT_NAME).toBe("xterm");
 	});
 });
-

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4,6 +4,7 @@ import { dlopen, FFIType, ptr } from "bun:ffi";
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "./interfaces";
 import type { IPty, IPtyForkOptions, IExitEvent } from "./interfaces";
+import { libraryFilenames } from "./library";
 import { join, dirname, basename } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 
@@ -50,7 +51,7 @@ function resolveLibPath(): string {
 	// See: https://github.com/sursaone/bun-pty/issues/19
 	try {
 		// @ts-ignore - require returns path for binary files in Bun
-		const embeddedPath = require(`../rust-pty/target/release/${process.platform === "win32" ? "rust_pty.dll" : process.platform === "darwin" ? (process.arch === "arm64" ? "librust_pty_arm64.dylib" : "librust_pty.dylib") : process.arch === "arm64" ? "librust_pty_arm64.so" : "librust_pty.so"}`);
+		const embeddedPath = require(`../rust-pty/target/release/${process.platform === "win32" ? (process.arch === "arm64" ? "rust_pty_arm64.dll" : "rust_pty.dll") : process.platform === "darwin" ? (process.arch === "arm64" ? "librust_pty_arm64.dylib" : "librust_pty.dylib") : process.arch === "arm64" ? "librust_pty_arm64.so" : "librust_pty.so"}`);
 		if (embeddedPath && !musl) return embeddedPath;
 	} catch {
 		// Not running as compiled binary, fall through to dynamic resolution
@@ -74,20 +75,7 @@ function resolveLibPath(): string {
 	const arch = process.arch;
 
 	// Try both architecture-specific and generic filenames
-	const filenames =
-		platform === "darwin"
-			? arch === "arm64"
-				? ["librust_pty_arm64.dylib", "librust_pty.dylib"]
-				: ["librust_pty.dylib"]
-			: platform === "win32"
-			? ["rust_pty.dll"]
-			: musl
-			? arch === "arm64"
-				? ["librust_pty_arm64_musl.so", "librust_pty_musl.so", "librust_pty_arm64.so", "librust_pty.so"]
-				: ["librust_pty_musl.so", "librust_pty.so"]
-			: arch === "arm64"
-			? ["librust_pty_arm64.so", "librust_pty.so"]
-			: ["librust_pty.so"];
+	const filenames = libraryFilenames(platform, arch, musl);
 
 	// Start from the current module's location
 	const base = Bun.fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary

- build and publish a native `rust_pty_arm64.dll` on GitHub's Windows ARM64 runner
- select the ARM64 DLL at runtime while preserving the existing x64 filename and local-build fallback
- statically link the MSVC runtime so the prebuilt DLL has no Visual C++ Redistributable prerequisite
- test the exact ARM64 artifact through unit, integration, and `bun build --compile` smoke tests

This fills the remaining native dependency gap for anomalyco/opencode#45875. The OpenCode installer and Bun upgrade are being handled separately in anomalyco/opencode#44665 and anomalyco/opencode#44946.

## Local verification

- Windows 11 ARM64 with Bun 1.4.0 ARM64
- PE machine type: `0xAA64`
- imported libraries: Windows system DLLs only; no `VCRUNTIME140.dll` or UCRT runtime imports
- 86 unit tests passed
- 11 integration tests passed, 5 platform-specific tests skipped
- compiled Windows ARM64 smoke executable ran outside the repository and successfully spawned a PTY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows ARM64, including native library selection and terminal process validation.
  * Improved native library discovery across platforms, architectures, and musl environments.

* **Documentation**
  * Updated platform support details to distinguish Windows x64 and ARM64 architectures.

* **Tests**
  * Added Windows ARM64 build, runtime, and native library resolution coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->